### PR TITLE
feat: [RABBIT-126] main 체결강도 api 연동

### DIFF
--- a/src/app/_api/bunnyAPI.ts
+++ b/src/app/_api/bunnyAPI.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { PressureResponse } from "../personal/home/_types/interfaces";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
 const TEST_TOKEN = process.env.NEXT_PUBLIC_TEST_TOKEN;
@@ -256,5 +257,18 @@ export const getBunnyContext = async (bunnyName: string) => {
             },
         }
     );
+    return response.data;
+};
+
+
+export const getPressureTop5 = async () => {
+    const response = await axios.get(`${API_BASE_URL}/bunnies/pressure-top5`, {
+        withCredentials: true,
+        headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${TEST_TOKEN}`,
+        },
+    });
+    
     return response.data;
 };

--- a/src/app/_components/FormPersonal.tsx
+++ b/src/app/_components/FormPersonal.tsx
@@ -23,10 +23,10 @@ export default function FormPersonal() {
                 <FeatureTitle>이런 기업을 원해요!</FeatureTitle>
                 <FeatureList>
                     <FeatureItem>
-                        <FeatureText><CheckIcon><Check color="#14ae5c" size={16} /></CheckIcon>개발자로서 자신을 홍보하고 싶은 사람</FeatureText>
+                        <FeatureText><CheckIcon><Check color="#14ae5c" size={16} /></CheckIcon> 개발자로서 자신을 홍보하고 싶은 사람</FeatureText>
                     </FeatureItem>
                     <FeatureItem>
-                        <FeatureText><CheckIcon><Check color="#14ae5c" size={16} /></CheckIcon>유망한 개발자를 발굴하고 투자하고자 하는 사람</FeatureText>
+                        <FeatureText><CheckIcon><Check color="#14ae5c" size={16} /></CheckIcon> 유망한 개발자를 발굴하고 투자하고자 하는 사람</FeatureText>
                     </FeatureItem>
                 </FeatureList>
             </FeatureBox>

--- a/src/app/personal/home/_components/Rank.tsx
+++ b/src/app/personal/home/_components/Rank.tsx
@@ -1,20 +1,21 @@
 import styled from "styled-components";
-import { DataType } from "../_types/interfaces";
+import { BunnyPressureData } from "../_types/interfaces";
 
 interface RankProps {
-    data: DataType;
+    rank: number;
+    data: BunnyPressureData;
 }
 
-function Rank({ data }: RankProps) {
+function Rank({ rank, data }: RankProps) {
     return (
         <Div>
             <Line>
                 <div>
-                    <Number>{data.id + 1}</Number>
-                    <CoinName>{data.coin_name}</CoinName>
+                    <Number>{rank}</Number>
+                    <CoinName>{data.bunny_name}</CoinName>
                 </div>
                 <div>
-                    <Percent>{data.percent}</Percent>
+                    <Percent>{Math.min(data.pressure, 500)}</Percent>
                     <span>%</span>
                 </div>
             </Line>

--- a/src/app/personal/home/_components/RankList.tsx
+++ b/src/app/personal/home/_components/RankList.tsx
@@ -1,0 +1,36 @@
+"use client";
+import { useEffect, useState } from "react";
+import Rank from "./Rank";
+import { getPressureTop5 } from "@/app/_api/bunnyAPI";
+import { BunnyPressureData, PressureResponse } from "../_types/interfaces";
+
+interface RankListProps {
+  type: "buy" | "sell";
+}
+
+export function RankList({ type }: RankListProps) {
+  const [data, setData] = useState<BunnyPressureData[]>([]);
+
+  useEffect(() => {
+    async function fetchData() {
+        try {
+            const res: PressureResponse = await getPressureTop5();
+
+            setData(type === "buy" ? res.buy_top5 : res.sell_top5);
+        } catch (err) {
+            console.error("압력 데이터 가져오기 실패:", err);
+        }
+    }
+    fetchData();
+  }, [type]);
+
+  if (!data || data.length === 0) return <div>Loading...</div>;
+
+  return (
+    <>
+        {data.map((item, i) => (
+            <Rank key={`${type}-${item.bunny_id}`} rank={i + 1} data={item} />
+        ))}
+    </>
+  );
+}

--- a/src/app/personal/home/_mocks/mocks.ts
+++ b/src/app/personal/home/_mocks/mocks.ts
@@ -1,34 +1,34 @@
 import { DataType, ListDataType } from "../_types/interfaces";
 
-export const RankData: DataType[] = [
+const RankData: DataType[] = [
     {
         id: 0,
-        coin_name: "coin1",
+        bunny_name: "coin1",
         percent: 200.3,
     },
     {
         id: 1,
-        coin_name: "coin2",
+        bunny_name: "coin2",
         percent: 200.3,
     },
     {
         id: 2,
-        coin_name: "coin3",
+        bunny_name: "coin3",
         percent: 200.3,
     },
     {
         id: 3,
-        coin_name: "coin4",
+        bunny_name: "coin4",
         percent: 200.3,
     },
     {
         id: 4,
-        coin_name: "coin5",
+        bunny_name: "coin5",
         percent: 200.3,
     },
 ];
 
-export const Data: ListDataType[] = [
+const Data: ListDataType[] = [
     {
         id: 0,
         coin_name: "coin1",

--- a/src/app/personal/home/_types/interfaces.ts
+++ b/src/app/personal/home/_types/interfaces.ts
@@ -1,9 +1,10 @@
 
 export interface DataType {
     id: number;
-    coin_name: string;
+    bunny_name: string;
     percent: number;
 }
+
 
 export interface BadgeType {
     id: number;
@@ -22,4 +23,16 @@ export interface ListDataType {
     fluctuation_rate: number;
     current_price: number;
     badge: string[];
+}
+
+export interface BunnyPressureData {
+  bunny_id: string;
+  bunny_name: string;
+  date: string;
+  pressure: number;
+}
+
+export interface PressureResponse {
+  buy_top5: BunnyPressureData[];
+  sell_top5: BunnyPressureData[];
 }

--- a/src/app/personal/home/page.tsx
+++ b/src/app/personal/home/page.tsx
@@ -6,15 +6,15 @@ import Title from "./_components/Title";
 import SortButton from "./_components/SortButton";
 import MarketScore from "../../_shared/components/MarketScore";
 import Top5 from "./_components/Top5";
-import Rank from "./_components/Rank";
 import Banner from "./_components/BannerContainer";
 import Alarm from "./_components/Alarm";
 import WithAuth from "@/app/_components/WithAuth";
 
-import { updateData, RankData } from "./_mocks/mocks";
+import { updateData } from "./_mocks/mocks";
 import { SelectData, notificationData } from "./_constants/constants";
 import { ListContainer, BunnyListContainer } from "./_components/ListContainer";
 import { BadgeContainer } from "./_components/BadgeContainer";
+import { RankList } from "./_components/RankList";
 import HeaderForCorporation from "@/app/_shared/components/HeaderForCorporation";
 
 function Personal() {
@@ -110,9 +110,7 @@ function Personal() {
                                 time={false}
                             />
                             <RankContainer>
-                                {RankData.map((data, i) => (
-                                    <Rank key={i} data={data} />
-                                ))}
+                                <RankList type="buy" />
                             </RankContainer>
                         </Container>
 
@@ -126,9 +124,7 @@ function Personal() {
                                 time={false}
                             />
                             <RankContainer>
-                                {RankData.map((data, i) => (
-                                    <Rank key={i} data={data} />
-                                ))}
+                                <RankList type="sell" />
                             </RankContainer>
                         </Container>
                         {/*                         


### PR DESCRIPTION
## 📌 작업 개요
- main 체결강도 api 연동

## ✅ 작업 상세
- main 페이지의 매수/ 매도 체결강도 api 연동

## 🎫 관련 이슈
- [RABBIT-126](https://dssw5.atlassian.net/browse/RABBIT-126)

## 🎬 참고 이미지
<img width="537" height="789" alt="image" src="https://github.com/user-attachments/assets/927f62d5-9016-4761-b1c5-38bbc7f7abff" />
<img width="632" height="408" alt="image" src="https://github.com/user-attachments/assets/33e670a5-4cf4-4081-a821-cdc8802e449d" />

## 📎 기타
- 없음.
