### PR TITLE
refactor: [RABBIT-125] 현재가 WebSocket 및 Scheduler 프론트 연동

### DIFF
--- a/src/app/_api/bunnyAPI.ts
+++ b/src/app/_api/bunnyAPI.ts
@@ -74,22 +74,40 @@ export const postOrder = async (bunnyName: string, order: Order) => {
 };
 
 export const createOrder = async (
-    bunnyName: string,
-    orderRequest: OrderRequest
+  bunnyName: string,
+  orderRequest: { quantity: number; unit_price: number; order_type: "BUY" | "SELL" }
 ) => {
+  // 정수 강제 + 문자열로 전송(BigDecimal 정밀도 안전)
+  const payload = {
+    quantity: Math.trunc(orderRequest.quantity).toString(),
+    unit_price: Math.trunc(orderRequest.unit_price).toString(),
+    order_type: orderRequest.order_type, // "BUY" | "SELL"
+  };
+
+  try {
     const response = await axios.post(
-        `${API_BASE_URL}/bunnies/${bunnyName}/orders`,
-        orderRequest,
-        {
-            withCredentials: true,
-            headers: {
-                "Content-Type": "application/json",
-                Authorization: `Bearer ${TEST_TOKEN}`,
-            },
-        }
+      `${API_BASE_URL}/bunnies/${encodeURIComponent(bunnyName)}/orders`,
+      payload,
+      {
+        withCredentials: true,
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_TOKEN}`,
+        },
+      }
     );
     return response.data;
+  } catch (err: any) {
+    // 서버가 내려주는 에러 메시지 확인
+    console.error(
+      "createOrder error:",
+      err.response?.status,
+      err.response?.data || err.message
+    );
+    throw err;
+  }
 };
+
 
 export const cancelOrder = async (bunnyName: string, orderId: string) => {
     const response = await axios.delete(

--- a/src/app/_store/bunnyStore.ts
+++ b/src/app/_store/bunnyStore.ts
@@ -1,5 +1,12 @@
 import { create } from "zustand";
 import axios from "axios";
+import { webSocketService } from "../_utils/websocket";
+import {
+  PriceTick,
+  ClosingPriceUpdate,
+  toNum,
+  calcFluctuationRate,
+} from "../_utils/websocket";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
 const TEST_TOKEN = process.env.NEXT_PUBLIC_TEST_TOKEN;
@@ -63,6 +70,10 @@ interface BunnyState {
     updateBunnyLikeCount: (bunnyName: string, delta: number) => void;
     getBunnyLikeCount: (bunnyName: string) => number;
 
+    // 실시간 가격 스트림 제어
+    startPriceRealtime: (bunnyName: string) => Promise<void>;
+    stopPriceRealtime: (bunnyName: string) => void;
+
     filters: Filters;
     setFilter: (key: string, value: number | number[] | null) => void;
 }
@@ -102,7 +113,7 @@ export const useBunnyStore = create<BunnyState>((set, get) => ({
                 },
             });
 
-            const newBunnies = response.data.content;
+            const newBunnies: Bunny[] = response.data.content;
             if (page === 0) {
             set((state) => ({
                 bunnies: newBunnies,
@@ -157,7 +168,7 @@ export const useBunnyStore = create<BunnyState>((set, get) => ({
                 },
             });
 
-            const bunnies = response.data.content;
+            const bunnies: Bunny[] = response.data.content;
 
             set((state) => ({
                 allBunnies: bunnies,
@@ -212,6 +223,62 @@ export const useBunnyStore = create<BunnyState>((set, get) => ({
         const bunny = bunnies.find((b) => b.bunny_name === bunnyName);
         return bunny ? bunny.like_count : 0;
     },
+
+    startPriceRealtime: async (bunnyName: string) => {
+        // 1) ws 연결 보장
+        await webSocketService.connect();
+
+        // 2) 현재가 틱 구독
+        webSocketService.subscribeToCurrentPrice(bunnyName, (tick: PriceTick) => {
+            const cur = toNum(tick.currentPrice);
+
+            set((state) => {
+                const updateList = (list: Bunny[]) =>
+                    list.map((bunny) =>
+                        bunny.bunny_name === bunnyName
+                            ? {
+                                  ...bunny,
+                                  current_price: cur,
+                                  fluctuation_rate: calcFluctuationRate(cur, bunny.closing_price),
+                            }
+                            : bunny
+                    );
+                return {
+                    bunnies: updateList(state.bunnies),
+                    allBunnies: updateList(state.allBunnies),
+                };
+            });
+        });
+
+        // 3) 종가(자정 1회) 구독
+        webSocketService.subscribeToClosingPrice(bunnyName, (close: ClosingPriceUpdate) => {
+            const closing = toNum(close.closingPrice);
+
+            set((state) => {
+                const updateList = (list: Bunny[]) =>
+                    list.map((bunny) =>
+                        bunny.bunny_name === bunnyName
+                            ? {
+                                ...bunny,
+                                closing_price: closing,
+                                fluctuation_rate: calcFluctuationRate(bunny.current_price, closing),
+                            }
+                            : bunny
+                    );
+
+                return {
+                    bunnies: updateList(state.bunnies),
+                    allBunnies: updateList(state.allBunnies),
+                };
+            });
+        });
+    },
+
+    stopPriceRealtime: (bunnyName: string) => {
+        webSocketService.unsubscribeFromCurrentPrice(bunnyName);
+        webSocketService.unsubscribeFromClosingPrice(bunnyName);
+    },
+
 
     filters: {
         bunnyType: null,

--- a/src/app/_utils/websocket.ts
+++ b/src/app/_utils/websocket.ts
@@ -1,4 +1,4 @@
-import { Client } from '@stomp/stompjs';
+import { Client, StompSubscription } from '@stomp/stompjs';
 import SockJS from 'sockjs-client';
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
@@ -20,44 +20,90 @@ export interface OrderBookSnapshot {
 export interface OrderBookDiff {
   bunnyName: string;
   bidUpserts: Array<{ price: number; quantity: number }>;
-  bidDeletes: Array<{ price: number; quantity: number }>;
+  bidDeletes: number[];
   askUpserts: Array<{ price: number; quantity: number }>;
-  askDeletes: Array<{ price: number; quantity: number }>;   
-  currentPrice: number;
+  askDeletes: number[];
+  currentPrice?: number;
+  serverTime: number;
+}
+
+export interface PriceTick {
+  bunnyName: string;
+  currentPrice: string | number;
+  timestamp: number;
+}
+
+export interface ClosingPriceUpdate {
+  bunnyName: string;
+  closingPrice: string | number;
+  date: string;
+}
+
+export function toNum(n: string | number | null | undefined): number {
+  if (n === null || n === undefined) return 0;
+  if (typeof n === 'number') return Number.isFinite(n) ? n : 0;
+  const parsed = Number(n);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export function calcFluctuationRate(currentPrice: number, closingPrice: number): number {
+  if (!closingPrice || closingPrice === 0) return 0;
+  return ((currentPrice - closingPrice) / closingPrice) * 100;
 }
 
 class WebSocketService {
   private client: Client | null = null;
-  private subscriptions: Map<string, any> = new Map();
+  private subscriptions: Map<string, StompSubscription> = new Map();
+  private desiredSubscriptions: Map<string, (data: any) => void> = new Map();
 
   connect() {
-    if (this.client?.connected) {
-      return Promise.resolve();
-    }
+    if (this.client?.connected) return Promise.resolve();
 
-    return new Promise<void>((resolve, reject) => {      
+    return new Promise<void>((resolve, reject) => {
       this.client = new Client({
-        webSocketFactory: () => new SockJS(`${API_BASE_URL}/ws/orderBook`, {
-          withCredentials: true
-        } as any),
-        connectHeaders: {
-          'Authorization': `Bearer ${TEST_TOKEN}`
+        webSocketFactory: () =>
+          new SockJS(`${API_BASE_URL}/ws/orderBook`, { withCredentials: true } as any),
+
+        // 자동 재연결 & 하트비트
+        reconnectDelay: 5000,     // 5초 간격 재시도
+        heartbeatIncoming: 10000, // 서버 → 클라
+        heartbeatOutgoing: 10000, // 클라 → 서버
+
+        // 연결 직전에 최신 토큰 반영
+        beforeConnect: () => {
+          const token = process.env.NEXT_PUBLIC_TEST_TOKEN ?? TEST_TOKEN;
+          this.client!.connectHeaders = { Authorization: `Bearer ${token}` };
         },
+
         debug: (str) => {
+          // 개발 중에는 켜두고, 운영에서는 끄는 걸 권장
           console.log('STOMP Debug:', str);
         },
+
         onConnect: () => {
           console.log('WebSocket 연결 성공');
+          // (재)연결 시 의도한 모든 구독 복구
+          this.resubscribeAll();
           resolve();
         },
+
         onStompError: (frame) => {
           console.error('STOMP 에러:', frame);
-          reject(new Error(frame.headers['message'] || 'WebSocket 연결 실패'));
+          if (!this.client?.connected) {
+            reject(new Error(frame.headers['message'] || 'WebSocket 연결 실패'));
+          }
         },
+
         onWebSocketError: (error) => {
           console.error('WebSocket 에러:', error);
-          reject(error);
-        }
+          if (!this.client?.connected) {
+            reject(error);
+          }
+        },
+
+        onWebSocketClose: () => {
+          console.warn('WebSocket 닫힘: 자동 재연결 대기 중...');
+        },
       });
 
       this.client.activate();
@@ -65,74 +111,125 @@ class WebSocketService {
   }
 
   disconnect() {
-    if (this.client) {
-      this.client.deactivate();
+    try {
+      this.subscriptions.forEach((sub) => {
+        try { sub.unsubscribe(); } catch {}
+      });
+      this.subscriptions.clear();
+      this.desiredSubscriptions.clear();
+      this.client?.deactivate();
+    } finally {
       this.client = null;
     }
-    this.subscriptions.clear();
   }
 
-  // 호가창 스냅샷 요청
+  // 공통 구독: 의도 저장 → 실제 subscribe (연결 상태에 따라 지연될 수 있음)
+  private subscribeRaw(destination: string, handler: (data: any) => void) {
+    // 중복 방지: 기존 동일 목적지 구독 삭제
+    if (this.desiredSubscriptions.has(destination)) {
+      this.unsubscribe(destination);
+    }
+
+    this.desiredSubscriptions.set(destination, handler);
+
+    if (!this.client?.connected) {
+      console.warn('연결 전 구독 요청 — 연결되면 자동 재구독됩니다:', destination);
+      return;
+    }
+
+    const sub = this.client.subscribe(destination, (message) => {
+      try {
+        const data = JSON.parse(message.body);
+        handler(data);
+      } catch (err) {
+        console.error('메시지 파싱 오류:', err, message.body);
+      }
+    });
+    this.subscriptions.set(destination, sub);
+  }
+
+  // 실제 구독 해제 + 의도 삭제
+  private unsubscribe(destination: string) {
+    const sub = this.subscriptions.get(destination);
+    if (sub) {
+      try { sub.unsubscribe(); } catch {}
+      this.subscriptions.delete(destination);
+    }
+    this.desiredSubscriptions.delete(destination);
+  }
+
+  // (재)연결 직후: 저장된 의도대로 전부 재구독
+  private resubscribeAll() {
+    // 기존 실제 구독은 폐기
+    this.subscriptions.forEach((sub) => {
+      try { sub.unsubscribe(); } catch {}
+    });
+    this.subscriptions.clear();
+
+    // 의도대로 다시 subscribe
+    this.desiredSubscriptions.forEach((handler, destination) => {
+      const sub = this.client!.subscribe(destination, (message) => {
+        try {
+          const data = JSON.parse(message.body);
+          handler(data);
+        } catch (err) {
+          console.error('메시지 파싱 오류:', err, message.body);
+        }
+      });
+      this.subscriptions.set(destination, sub);
+    });
+  }
+
+  // OrderBook (스냅샷 1회 + diff 다회차)
   requestOrderBookSnapshot(bunnyName: string) {
     if (!this.client?.connected) {
       console.error('WebSocket이 연결되지 않았습니다.');
       return;
     }
-
-    const TEST_TOKEN = process.env.NEXT_PUBLIC_TEST_TOKEN;
-
+    const token = process.env.NEXT_PUBLIC_TEST_TOKEN ?? TEST_TOKEN;
     this.client.publish({
       destination: `/app/bunnies/${bunnyName}/orderbook.snapshot`,
-      headers: {
-        'Authorization': `Bearer ${TEST_TOKEN}`
-      }
+      headers: { Authorization: `Bearer ${token}` },
     });
   }
 
-  // 호가창 데이터 구독
   subscribeToOrderBook(
-    bunnyName: string, 
+    bunnyName: string,
     onSnapshot: (data: OrderBookSnapshot) => void,
     onDiff: (data: OrderBookDiff) => void
   ) {
-    if (!this.client?.connected) {
-      console.error('WebSocket이 연결되지 않았습니다.');
-      return;
-    }
-
     const destination = `/topic/bunnies/${bunnyName}/orderbook`;
-    
-    const subscription = this.client.subscribe(destination, (message) => {
-      try {
-        const data = JSON.parse(message.body);
-        
-        // 스냅샷인지 차이인지 구분
-        if (data.bids && data.asks && !data.bidUpserts) {
-          // 스냅샷 데이터
-          onSnapshot(data as OrderBookSnapshot);
-        } else {
-          // 차이 데이터
-          onDiff(data as OrderBookDiff);
-        }
-      } catch (error) {
-        console.error('WebSocket 메시지 파싱 오류:', error);
+    this.subscribeRaw(destination, (data) => {
+      // 스냅샷/차이 구분
+      if (data.bids && data.asks && !data.bidUpserts) {
+        onSnapshot(data as OrderBookSnapshot);
+      } else {
+        onDiff(data as OrderBookDiff);
       }
     });
-
-    this.subscriptions.set(destination, subscription);
-    return subscription;
   }
 
   unsubscribeFromOrderBook(bunnyName: string) {
-    const destination = `/topic/bunnies/${bunnyName}/orderbook`;
-    const subscription = this.subscriptions.get(destination);
-    
-    if (subscription) {
-      subscription.unsubscribe();
-      this.subscriptions.delete(destination);
-    }
+    this.unsubscribe(`/topic/bunnies/${bunnyName}/orderbook`);
+  }
+
+  // 현재가 틱 (다회차)
+  subscribeToCurrentPrice(bunnyName: string, onTick: (tick: PriceTick) => void) {
+    const destination = `/topic/price/${bunnyName}`;
+    this.subscribeRaw(destination, (data) => onTick(data as PriceTick));
+  }
+  unsubscribeFromCurrentPrice(bunnyName: string) {
+    this.unsubscribe(`/topic/price/${bunnyName}`);
+  }
+
+  // 종가 (자정 1회)
+  subscribeToClosingPrice(bunnyName: string, onClose: (close: ClosingPriceUpdate) => void) {
+    const destination = `/topic/close/${bunnyName}`;
+    this.subscribeRaw(destination, (data) => onClose(data as ClosingPriceUpdate));
+  }
+  unsubscribeFromClosingPrice(bunnyName: string) {
+    this.unsubscribe(`/topic/close/${bunnyName}`);
   }
 }
 
 export const webSocketService = new WebSocketService();
-

--- a/src/app/personal/trade/components/CurrentPrice.tsx
+++ b/src/app/personal/trade/components/CurrentPrice.tsx
@@ -1,16 +1,44 @@
 "use client";
 import styled from "styled-components";
-import { Bunny } from "../../../_store/bunnyStore";
+import { useEffect, useMemo } from "react";
+import { Bunny, useBunnyStore } from "../../../_store/bunnyStore";
 
 interface CurrentPriceProps {
   bunny: Bunny;
 }
 
 export default function CurrentPrice({ bunny }: CurrentPriceProps) {
-  const price = bunny.current_price.toLocaleString();
-  const change = bunny.fluctuation_rate ? (bunny.current_price - bunny.closing_price).toLocaleString() : "0";
-  const changePercentage = bunny.fluctuation_rate ? `(${bunny.fluctuation_rate > 0 ? '+' : ''}${bunny.fluctuation_rate.toFixed(2)}%)` : "(0.00%)";
-  const isPositive = bunny.fluctuation_rate ? bunny.fluctuation_rate >= 0 : true;
+  // 스토어에서 실시간 값 읽기
+  const { bunnies, allBunnies, startPriceRealtime, stopPriceRealtime } = useBunnyStore();
+
+  // 현재 화면 대상 bunnyName
+  const bunnyName = bunny.bunny_name;
+
+  // 스토어에서 동일 bunny 찾기 (실시간 값 우선)
+  const live = useMemo(() => {
+    const foundInAll = allBunnies.find((bunny) => bunny.bunny_name === bunnyName);
+    if (foundInAll) return foundInAll;
+    return bunnies.find((bunny) => bunny.bunny_name === bunnyName);
+  }, [allBunnies, bunnies, bunnyName]);
+
+  // 마운트 시 구독 시작, 언마운트 시 해제
+  useEffect(() => {
+    startPriceRealtime(bunnyName);
+    return () => {
+      stopPriceRealtime(bunnyName);
+    };
+  }, [bunnyName, startPriceRealtime, stopPriceRealtime]);
+
+  // 표시값: 스ㅌ어 값이 있으면 사용, 없으면 prop 값 사용
+  const current = live?.current_price ?? bunny.current_price ?? 0;
+  const close   = live?.closing_price ?? bunny.closing_price ?? 0;
+  const rate    = live?.fluctuation_rate ?? bunny.fluctuation_rate ?? 0;
+
+  const price = Number(current).toLocaleString();
+  const change = (Number(current) - Number(close)).toLocaleString();
+  const changePercentage = `(${rate > 0 ? '+' : ''}${Number(rate).toFixed(2)}%)`;
+  const isPositive = Number(rate) >= 0;
+  
   return (
     <DashboardContent>
       <PriceSection>

--- a/src/app/personal/trade/components/Order.tsx
+++ b/src/app/personal/trade/components/Order.tsx
@@ -2,11 +2,15 @@
 import styled from "styled-components";
 import Button from '../../../_shared/components/Button';
 import { useState, useEffect } from "react";
-import { Bunny, useBunnyStore } from "../../../_store/bunnyStore";
+import { Bunny } from "../../../_store/bunnyStore"; // useBunnyStore는 이 파일에서 안 써서 제거
 import { useUserStore } from "../../../_store/userStore";
 import { validateOrderAmount, handlePriceIncrease } from '../utils/orderValidate';
 import { createOrder, getBunnyContext } from '../../../_api/bunnyAPI';
-import { webSocketService, OrderBookSnapshot, OrderBookDiff } from '../../../_utils/websocket';
+import {
+  webSocketService,
+  OrderBookSnapshot,
+  OrderBookDiff
+} from '../../../_utils/websocket';
 
 interface OrderProps {
   activeTab: string;
@@ -20,8 +24,15 @@ interface BunnyContext {
   sellable_quantity: number;
 }
 
+/** 숫자만 허용(정수), 앞자리 0 정리 */
+const toIntInput = (v: string) => {
+  const onlyDigits = v.replace(/[^\d]/g, "");
+  // 불필요한 선행 0 제거 (단, "0" 자체는 허용)
+  return onlyDigits.replace(/^0+(?=\d)/, "");
+};
+
 export default function Order({ activeTab, setActiveTab, bunny }: OrderProps) {
-  const [quantity, setQuantity] = useState('');
+  const [quantity, setQuantity] = useState(''); // 문자열 입력 상태
   const [price, setPrice] = useState('');
   const [showTooltip, setShowTooltip] = useState(false);
   const [bunnyContext, setBunnyContext] = useState<BunnyContext | null>(null);
@@ -29,131 +40,135 @@ export default function Order({ activeTab, setActiveTab, bunny }: OrderProps) {
   const [isWebSocketConnected, setIsWebSocketConnected] = useState(false);
   const { user } = useUserStore();
 
+  // 1) 컨텍스트(주문 가능 수량/액수 등) 로드
   useEffect(() => {
-    const fetchBunnyContext = async () => {
+    let mounted = true;
+    (async () => {
       try {
         const context = await getBunnyContext(bunny.bunny_name);
+        if (!mounted) return;
         setBunnyContext(context);
       } catch (error) {
         console.error('Bunny context 가져오기 실패:', error);
       }
-    };
-
-    fetchBunnyContext();
+    })();
+    return () => { mounted = false; };
   }, [bunny.bunny_name]);
 
-  // 웹소켓 연결 및 호가창 구독
+  // 2) 웹소켓 연결 + 호가창 스냅샷 요청 + 구독 설정
   useEffect(() => {
-    const connectWebSocket = async () => {
+    let mounted = true;
+
+    (async () => {
       try {
         await webSocketService.connect();
+        if (!mounted) return;
         setIsWebSocketConnected(true);
-        
-        // 호가창 스냅샷 요청
+
+        // 최초 1회 스냅샷 요청
         webSocketService.requestOrderBookSnapshot(bunny.bunny_name);
-        
-        // 호가창 구독
-        const subscription = webSocketService.subscribeToOrderBook(
+
+        // 실시간 호가창 구독(스냅샷/디프 분기)
+        webSocketService.subscribeToOrderBook(
           bunny.bunny_name,
           (snapshot: OrderBookSnapshot) => {
-            console.log('호가창 스냅샷 수신:', snapshot);
             setOrderBook(snapshot);
           },
           (diff: OrderBookDiff) => {
-            console.log('호가창 차이 수신:', diff);
-            // 차이 데이터를 기반으로 호가창 업데이트
-            setOrderBook(prev => {
+            setOrderBook((prev) => {
               if (!prev) return null;
-              
-              // 새로운 호가창 데이터 생성
-              const newOrderBook = { ...prev };
-              
-              // 매수 호가 업데이트
-              diff.bidUpserts.forEach(upsert => {
-                const existingIndex = newOrderBook.bids.findIndex(bid => bid.price === upsert.price);
-                if (existingIndex >= 0) {
-                  newOrderBook.bids[existingIndex] = upsert;
-                } else {
-                  newOrderBook.bids.push(upsert);
-                }
+
+              const next = { ...prev };
+
+              // 매수 upsert
+              diff.bidUpserts.forEach((u) => {
+                const i = next.bids.findIndex((b) => b.price === u.price);
+                if (i >= 0) next.bids[i] = u;
+                else next.bids.push(u);
               });
-              
-              diff.bidDeletes.forEach(del => {
-                newOrderBook.bids = newOrderBook.bids.filter(bid => bid.price !== del.price);
+              // 매수 delete (숫자 배열: 가격)
+              diff.bidDeletes.forEach((price) => {
+                next.bids = next.bids.filter((b) => b.price !== price);
               });
-              
-              // 매도 호가 업데이트
-              diff.askUpserts.forEach(upsert => {
-                const existingIndex = newOrderBook.asks.findIndex(ask => ask.price === upsert.price);
-                if (existingIndex >= 0) {
-                  newOrderBook.asks[existingIndex] = upsert;
-                } else {
-                  newOrderBook.asks.push(upsert);
-                }
+
+              // 매도 upsert
+              diff.askUpserts.forEach((u) => {
+                const i = next.asks.findIndex((a) => a.price === u.price);
+                if (i >= 0) next.asks[i] = u;
+                else next.asks.push(u);
               });
-              
-              diff.askDeletes.forEach(del => {
-                newOrderBook.asks = newOrderBook.asks.filter(ask => ask.price !== del.price);
+              // 매도 delete (숫자 배열: 가격)
+              diff.askDeletes.forEach((price) => {
+                next.asks = next.asks.filter((a) => a.price !== price);
               });
-              
-              // 가격 정렬
-              newOrderBook.bids.sort((a, b) => b.price - a.price);
-              newOrderBook.asks.sort((a, b) => a.price - b.price);
-              
-              // 현재 가격 업데이트
-              if (diff.currentPrice) {
-                newOrderBook.currentPrice = diff.currentPrice;
+
+              // 정렬 (매수: 내림차순, 매도: 오름차순)
+              next.bids.sort((a, b) => b.price - a.price);
+              next.asks.sort((a, b) => a.price - b.price);
+
+              // 현재가 갱신(optional)
+              if (typeof diff.currentPrice === 'number') {
+                next.currentPrice = diff.currentPrice;
               }
-              
-              return newOrderBook;
+
+              return next;
             });
           }
         );
-        
-        return () => {
-          if (subscription) {
-            webSocketService.unsubscribeFromOrderBook(bunny.bunny_name);
-          }
-        };
       } catch (error) {
         console.error('웹소켓 연결 실패:', error);
-        setIsWebSocketConnected(false);
+        if (mounted) setIsWebSocketConnected(false);
       }
-    };
+    })();
 
-    connectWebSocket();
-    
-    // 컴포넌트 언마운트 시 웹소켓 연결 해제
+    // cleanup: 구독 해제만 여기서 수행
     return () => {
+      mounted = false;
       webSocketService.unsubscribeFromOrderBook(bunny.bunny_name);
     };
   }, [bunny.bunny_name]);
 
-
+  // 가격 +% 버튼
   const onPriceIncrease = (percentage: number) => {
     const currentPrice = orderBook?.currentPrice || bunny.current_price;
     const newPrice = handlePriceIncrease(price, currentPrice, percentage);
-    setPrice(newPrice);
+    setPrice(toIntInput(newPrice)); // 정수만 유지
   };
 
-  // 호가창에서 가격 선택
+  // 호가 클릭하여 가격 입력
   const selectPrice = (selectedPrice: number) => {
-    setPrice(selectedPrice.toString());
+    setPrice(String(selectedPrice));
   };
 
+  // 주문 유효성 (금액은 기존 로직 유지)
   const orderValidation = validateOrderAmount(quantity, price);
   const isOrderValid = orderValidation.isValid;
 
+  // 주문 처리
   const handleOrder = async () => {
     try {
-      const orderRequest = {
-        quantity: parseFloat(quantity),
-        unit_price: parseFloat(price),
-        order_type: activeTab === '매수' ? 'BUY' : 'SELL'
-      };
+      // 입력을 정수로 강제(백엔드: BigDecimal 정수 + @Digits(fraction=0))
+      const qtyStr = toIntInput(quantity);
+      const unitStr = toIntInput(price);
 
-      await createOrder(bunny.bunny_name, orderRequest);
-      
+      const qty = Number(qtyStr);
+      const unit = Number(unitStr);
+
+      if (!Number.isFinite(qty) || qty <= 0) {
+        alert("수량은 0보다 큰 정수여야 합니다.");
+        return;
+      }
+      if (!Number.isFinite(unit) || unit <= 0) {
+        alert("가격은 0보다 큰 정수여야 합니다.");
+        return;
+      }
+
+      await createOrder(bunny.bunny_name, {
+        quantity: qty,
+        unit_price: unit,
+        order_type: activeTab === '매수' ? 'BUY' : 'SELL',
+      });
+
       setQuantity('');
       setPrice('');
       alert(`${activeTab} 주문이 성공적으로 처리되었습니다.`);
@@ -170,102 +185,90 @@ export default function Order({ activeTab, setActiveTab, bunny }: OrderProps) {
   return (
     <>
       <TabContainer>
-        <TabButton 
-          $active={activeTab === '매수'} 
+        <TabButton
+          $active={activeTab === '매수'}
           $type="buy"
           onClick={() => setActiveTab('매수')}
         >
           매수
         </TabButton>
-        <TabButton 
-          $active={activeTab === '매도'} 
+        <TabButton
+          $active={activeTab === '매도'}
           $type="sell"
           onClick={() => setActiveTab('매도')}
         >
           매도
         </TabButton>
       </TabContainer>
+
       <TradeArea>
         <OrderForm>
           {/* 현재 가격 및 웹소켓 연결 상태 */}
           <OrderRow>
             <OrderLabel>현재 가격</OrderLabel>
             <OrderValue>
-              {orderBook?.currentPrice?.toLocaleString() || bunny.current_price?.toLocaleString() || 0} C
+              {orderBook?.currentPrice?.toLocaleString() ||
+                bunny.current_price?.toLocaleString() ||
+                0}{' '}
+              C
               {isWebSocketConnected && <ConnectionStatus $connected={true}>●</ConnectionStatus>}
               {!isWebSocketConnected && <ConnectionStatus $connected={false}>●</ConnectionStatus>}
             </OrderValue>
           </OrderRow>
-          
+
           <OrderRow>
             <OrderLabel>{activeTab === '매수' ? '주문 가능' : '매도 가능'}</OrderLabel>
             <OrderValue>
-              {activeTab === '매수' 
+              {activeTab === '매수'
                 ? `${bunnyContext?.buyable_amount?.toLocaleString() || 0} C`
-                : `${bunnyContext?.sellable_quantity || 0} C`
-              }
+                : `${bunnyContext?.sellable_quantity || 0} C`}
             </OrderValue>
           </OrderRow>
-          
+
           <OrderRow>
             <OrderLabel>주문 수량</OrderLabel>
             <OrderInput>
-              <input 
-                type="text" 
-                placeholder="0" 
+              <input
+                type="text"
+                inputMode="numeric"
+                placeholder="0"
                 value={quantity}
-                onChange={(e) => setQuantity(e.target.value)}
+                onChange={(e) => setQuantity(toIntInput(e.target.value))}
               />
               <span>BNY</span>
             </OrderInput>
           </OrderRow>
-          
+
           <OrderRow>
             <OrderLabel>{activeTab === '매수' ? '매수 가격' : '매도 가격'}</OrderLabel>
             <OrderInput>
-              <input 
-                type="text" 
-                placeholder="0" 
+              <input
+                type="text"
+                inputMode="numeric"
+                placeholder="0"
                 value={price}
-                onChange={(e) => setPrice(e.target.value)}
+                onChange={(e) => setPrice(toIntInput(e.target.value))}
               />
               <span>C</span>
             </OrderInput>
           </OrderRow>
-          
+
           <PercentageButtons>
-            <PercentageButton 
-              onClick={() => onPriceIncrease(10)}
-            >
-              +10%
-            </PercentageButton>
-            <PercentageButton 
-              onClick={() => onPriceIncrease(20)}
-            >
-              +20%
-            </PercentageButton>
-            <PercentageButton 
-              onClick={() => onPriceIncrease(50)}
-            >
-              +50%
-            </PercentageButton>
-            <PercentageButton 
-              onClick={() => onPriceIncrease(100)}
-            >
-              +100%
-            </PercentageButton>
+            <PercentageButton onClick={() => onPriceIncrease(10)}>+10%</PercentageButton>
+            <PercentageButton onClick={() => onPriceIncrease(20)}>+20%</PercentageButton>
+            <PercentageButton onClick={() => onPriceIncrease(50)}>+50%</PercentageButton>
+            <PercentageButton onClick={() => onPriceIncrease(100)}>+100%</PercentageButton>
           </PercentageButtons>
-          
+
           <OrderRow>
             <OrderLabel>주문 총액</OrderLabel>
             <OrderValue>
-              {quantity && price 
-                ? `${Math.round(parseFloat(quantity) * parseFloat(price) * 1.001).toLocaleString()} C`
-                : '0 C'
-              }
+              {quantity && price
+                ? `${Math.round(Number(quantity) * Number(price) * 1.001).toLocaleString()} C`
+                : '0 C'}
             </OrderValue>
           </OrderRow>
-          
+
           {/* 간단한 호가창 표시 */}
           {orderBook && (
             <OrderBookSection>
@@ -273,8 +276,8 @@ export default function Order({ activeTab, setActiveTab, bunny }: OrderProps) {
               <OrderBookContainer>
                 <BidSection>
                   <BidTitle>매수</BidTitle>
-                  {orderBook.bids.slice(0, 3).map((bid, index) => (
-                    <OrderBookRow 
+                  {orderBook.bids.slice(0, 3).map((bid) => (
+                    <OrderBookRow
                       key={`bid-${bid.price}`}
                       onClick={() => selectPrice(bid.price)}
                       $type="bid"
@@ -286,8 +289,8 @@ export default function Order({ activeTab, setActiveTab, bunny }: OrderProps) {
                 </BidSection>
                 <AskSection>
                   <AskTitle>매도</AskTitle>
-                  {orderBook.asks.slice(0, 3).map((ask, index) => (
-                    <OrderBookRow 
+                  {orderBook.asks.slice(0, 3).map((ask) => (
+                    <OrderBookRow
                       key={`ask-${ask.price}`}
                       onClick={() => selectPrice(ask.price)}
                       $type="ask"
@@ -300,28 +303,26 @@ export default function Order({ activeTab, setActiveTab, bunny }: OrderProps) {
               </OrderBookContainer>
             </OrderBookSection>
           )}
-          
+
           <ActionButtons>
-            <Button variant="secondary" size="small" onClick={handleReset}>초기화</Button>
+            <Button variant="secondary" size="small" onClick={handleReset}>
+              초기화
+            </Button>
             <ButtonContainer>
-              <Button 
-                variant="primary" 
+              <Button
+                variant="primary"
                 size="small"
                 disabled={!isOrderValid}
                 onClick={handleOrder}
                 onMouseEnter={() => {
-                  if (!isOrderValid) {
-                    setShowTooltip(true);
-                  }
+                  if (!isOrderValid) setShowTooltip(true);
                 }}
                 onMouseLeave={() => setShowTooltip(false)}
               >
                 {activeTab === '매수' ? '매수하기' : '매도하기'}
               </Button>
               {showTooltip && !isOrderValid && (
-                <Tooltip>
-                  최소 주문 금액은 1,000C입니다
-                </Tooltip>
+                <Tooltip>최소 주문 금액은 1,000C입니다</Tooltip>
               )}
             </ButtonContainer>
           </ActionButtons>
@@ -331,6 +332,7 @@ export default function Order({ activeTab, setActiveTab, bunny }: OrderProps) {
   );
 }
 
+/* ==== styled-components (변경 없음) ==== */
 
 const TabContainer = styled.div`
   display: flex;
@@ -349,8 +351,8 @@ const TabButton = styled.button<{ $active: boolean; $type: 'buy' | 'sell' }>`
   cursor: pointer;
   transition: all 0.3s ease;
   border-radius: 0.5rem 0.5rem 0 0;
-  
-  ${({ $active, $type }) => {
+
+  ${({ $active }) => {
     if ($active) {
       return `
         background-color: rgba(252, 252, 252, 0.34);
@@ -409,7 +411,7 @@ const OrderInput = styled.div`
   padding: 0.4rem;
   min-width: 100px;
   max-width: 110px;
-  
+
   input {
     border: none;
     background: transparent;
@@ -418,12 +420,12 @@ const OrderInput = styled.div`
     font-size: 0.85rem;
     color: #333;
     min-width: 0;
-    
+
     &::placeholder {
       color: #999;
     }
   }
-  
+
   span {
     font-size: 0.75rem;
     color: #666;
@@ -449,12 +451,12 @@ const PercentageButton = styled.button`
   transition: all 0.3s ease;
   color: white;
   background-color: rgba(27, 101, 164, 1);
-  
+
   &:hover {
     background-color: rgba(16, 145, 255, 0.7);
     transform: translateY(-1px);
   }
-  
+
   &:active {
     transform: translateY(0);
     background-color: rgba(16, 145, 255, 0.9);
@@ -489,7 +491,7 @@ const Tooltip = styled.div`
   z-index: 1000;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
   pointer-events: none;
-  
+
   &::after {
     content: '';
     position: absolute;
@@ -503,7 +505,7 @@ const Tooltip = styled.div`
 
 const ConnectionStatus = styled.span<{ $connected: boolean }>`
   margin-left: 0.5rem;
-  color: ${({ $connected }) => $connected ? '#4CAF50' : '#F44336'};
+  color: ${({ $connected }) => ($connected ? '#4CAF50' : '#F44336')};
   font-size: 0.8rem;
 `;
 
@@ -561,27 +563,21 @@ const OrderBookRow = styled.div<{ $type: 'bid' | 'ask' }>`
   cursor: pointer;
   transition: all 0.2s ease;
   font-size: 0.8rem;
-  
-  background-color: ${({ $type }) => 
-    $type === 'bid' 
-      ? 'rgba(76, 175, 80, 0.1)' 
-      : 'rgba(244, 67, 54, 0.1)'
-  };
-  
+
+  background-color: ${({ $type }) =>
+    $type === 'bid' ? 'rgba(76, 175, 80, 0.1)' : 'rgba(244, 67, 54, 0.1)'};
+
   &:hover {
-    background-color: ${({ $type }) => 
-      $type === 'bid' 
-        ? 'rgba(76, 175, 80, 0.2)' 
-        : 'rgba(244, 67, 54, 0.2)'
-    };
+    background-color: ${({ $type }) =>
+      $type === 'bid' ? 'rgba(76, 175, 80, 0.2)' : 'rgba(244, 67, 54, 0.2)'};
     transform: translateY(-1px);
   }
-  
+
   span:first-child {
     font-weight: 600;
     color: #333;
   }
-  
+
   span:last-child {
     color: #666;
   }


### PR DESCRIPTION
## 📌 작업 개요
- 현재가 WebSocket 및 Scheduler 프론트 연동

## ✅ 작업 상세
- 현재가를 체결 시마다 웹소켓으로 보여지도록 구현
- 종가를 마감시간(0 1 0 * * *) 마다 갱신하도록 구현
- 모든 currentPrice와 ClosingPrice가 실시간으로 set되도록 함

## 🎫 관련 이슈
- [RABBIT-125](https://dssw5.atlassian.net/browse/RABBIT-125)

## 🎬 참고 이미지
- <img width="422" height="232" alt="image" src="https://github.com/user-attachments/assets/aa192e92-95b7-402e-b5c7-a294685a5d7b" />
- 18000에서 20000으로 오른 모습 (재웅이랑 같이 확인)

## 📎 기타
- 모든 웹소켓에서 간헐적으로 실시간 적용이 안되는 모습이 보임
- 메인의 '로켓에 탑승한 버니들' 같은 경우엔 새로고침 이외에 재차 랜더링을 할 수 없어서 실시간 반영이 안 보여지는 경우가 다수있음
