### PR TITLE
refactor: [RABBIT-135] 호가창 매수 매도 응답 통합

### DIFF
--- a/src/app/_api/bunnyAPI.ts
+++ b/src/app/_api/bunnyAPI.ts
@@ -19,12 +19,12 @@ export interface OrderRequest {
 export interface OrderBookItem {
     price: number;
     quantity: number;
+    type: 'BUY' | 'SELL';
 }
 
 export interface OrderBookData {
     bunnyName: string;
-    bids: OrderBookItem[];
-    asks: OrderBookItem[];
+    orders: Array<{ price: number; quantity: number; type: 'BUY' | 'SELL' }>;
     currentPrice: number;
     serverTime: number;
 }

--- a/src/app/_shared/components/SpaceBackground.tsx
+++ b/src/app/_shared/components/SpaceBackground.tsx
@@ -299,23 +299,23 @@ const GradientBackground = styled.div`
   @keyframes auroraFlow {
     0% {
       filter: saturate(1) brightness(1) contrast(1);
-      transform: scale(1) rotate(0deg);
+      transform: scale(1)
     }
     25% {
       filter: saturate(1.1) brightness(1.05) contrast(1.05);
-      transform: scale(1.02) rotate(1deg);
+      transform: scale(1.02)
     }
     50% {
       filter: saturate(1.2) brightness(1.1) contrast(1.1);
-      transform: scale(1.05) rotate(0deg);
+      transform: scale(1.05)
     }
     75% {
       filter: saturate(1.1) brightness(1.05) contrast(1.05);
-      transform: scale(1.02) rotate(-1deg);
+      transform: scale(1.02)
     }
     100% {
       filter: saturate(1) brightness(1) contrast(1);
-      transform: scale(1) rotate(0deg);
+      transform: scale(1)
     }
   }
 `;

--- a/src/app/_store/bunnyStore.ts
+++ b/src/app/_store/bunnyStore.ts
@@ -88,6 +88,7 @@ interface BunnyState {
     // 실시간 가격 스트림 제어
     startPriceRealtime: (bunnyName: string) => Promise<void>;
     stopPriceRealtime: (bunnyName: string) => void;
+    isWebSocketConnected: () => boolean;
 
     filters: Filters;
     setFilter: (key: string, value: number | number[] | null) => void;
@@ -362,6 +363,10 @@ export const useBunnyStore = create<BunnyState>((set, get) => ({
     stopPriceRealtime: (bunnyName: string) => {
         webSocketService.unsubscribeFromCurrentPrice(bunnyName);
         webSocketService.unsubscribeFromClosingPrice(bunnyName);
+    },
+
+    isWebSocketConnected: () => {
+        return webSocketService.isConnected();
     },
 
 

--- a/src/app/_utils/websocket.ts
+++ b/src/app/_utils/websocket.ts
@@ -12,18 +12,22 @@ declare global {
 
 export interface OrderBookSnapshot {
   bunnyName: string;
-  bids: Array<{ price: number; quantity: number }>;
-  asks: Array<{ price: number; quantity: number }>;
+  orders: Array<{ price: number; quantity: number; type: 'BUY' | 'SELL' }>;
   currentPrice: number;
+  serverTime: number;
+}
+
+export interface OrderBookLevel {
+  price: number;
+  quantity: number;
+  type: 'BUY' | 'SELL';
 }
 
 export interface OrderBookDiff {
   bunnyName: string;
-  bidUpserts: Array<{ price: number; quantity: number }>;
-  bidDeletes: number[];
-  askUpserts: Array<{ price: number; quantity: number }>;
-  askDeletes: number[];
-  currentPrice?: number;
+  orderUpserts: OrderBookLevel[];
+  orderDeletes: number[];
+  currentPrice: number;
   serverTime: number;
 }
 
@@ -52,7 +56,7 @@ export function calcFluctuationRate(currentPrice: number, closingPrice: number):
 }
 
 class WebSocketService {
-  private client: Client | null = null;
+  public client: Client | null = null;
   private subscriptions: Map<string, StompSubscription> = new Map();
   private desiredSubscriptions: Map<string, (data: any) => void> = new Map();
 
@@ -121,6 +125,10 @@ class WebSocketService {
     } finally {
       this.client = null;
     }
+  }
+
+  isConnected(): boolean {
+    return this.client?.connected ?? false;
   }
 
   // 공통 구독: 의도 저장 → 실제 subscribe (연결 상태에 따라 지연될 수 있음)
@@ -201,7 +209,7 @@ class WebSocketService {
     const destination = `/topic/bunnies/${bunnyName}/orderbook`;
     this.subscribeRaw(destination, (data) => {
       // 스냅샷/차이 구분
-      if (data.bids && data.asks && !data.bidUpserts) {
+      if (data.orders && !data.orderUpserts) {
         onSnapshot(data as OrderBookSnapshot);
       } else {
         onDiff(data as OrderBookDiff);

--- a/src/app/personal/funding/_modal/CreateBunnyModal.tsx
+++ b/src/app/personal/funding/_modal/CreateBunnyModal.tsx
@@ -227,7 +227,7 @@ export default function CreateBunnyModal({ isOpen, onClose }: CreateBunnyModalPr
                             )}
                         </Section>
 
-                        {/* 버니 타입 선택 섹션 */}
+                        {/* 버니 유형 선택 섹션 */}
                         <Section>
                             <TypeCardsContainer>
                                 <TypeCard

--- a/src/app/personal/home/_components/List.tsx
+++ b/src/app/personal/home/_components/List.tsx
@@ -105,7 +105,7 @@ function renderValue(
 
     if (fieldKey === "fluctuation_rate" && typeof value === "number") {
         const color = value > 0 ? "#ff5a5a" : value < 0 ? "#60a5fa" : "#fff";
-        return <span style={{ color, fontWeight: "800" }}>{value}%</span>;
+        return <span style={{ color, fontWeight: "800" }}>{value.toFixed(2)}%</span>;
     }
 
     if (fieldKey === "current_price") {

--- a/src/app/personal/home/_components/ListContainer.tsx
+++ b/src/app/personal/home/_components/ListContainer.tsx
@@ -14,7 +14,7 @@ export function getYesterdayMidnight(): Date {
 }
 
 export function ListContainer() {
-    const { allBunnies, fetchAllBunnies } = useBunnyStore();
+    const { allBunnies, fetchAllBunnies, startPriceRealtime, stopPriceRealtime } = useBunnyStore();
 
     useEffect(() => {
         if (!allBunnies || allBunnies.length === 0) {
@@ -30,6 +30,24 @@ export function ListContainer() {
         );
     }, [allBunnies]);
 
+    // 실시간 가격 구독 시작
+    useEffect(() => {
+        if (filteredList.length > 0) {
+            filteredList.forEach((bunny) => {
+                startPriceRealtime(bunny.bunny_name);
+            });
+        }
+
+        // 컴포넌트 언마운트 시 구독 해제
+        return () => {
+            if (filteredList.length > 0) {
+                filteredList.forEach((bunny) => {
+                    stopPriceRealtime(bunny.bunny_name);
+                });
+            }
+        };
+    }, [filteredList, startPriceRealtime, stopPriceRealtime]);
+
     return (
         <List
             fieldList={fieldList}
@@ -40,7 +58,7 @@ export function ListContainer() {
 }
 
 export function BunnyListContainer() {
-    const { bunnies, fetchBunnies, filters, status } = useBunnyStore();
+    const { bunnies, fetchBunnies, filters, status, startPriceRealtime, stopPriceRealtime } = useBunnyStore();
     const [page, setPage] = useState(0);
     const [size, setSize] = useState(10);
 
@@ -81,6 +99,24 @@ export function BunnyListContainer() {
     useEffect(() => {
         fetchBunnies({ sortType: "", page, size });
     }, [page, size, fetchBunnies]);
+
+    // 실시간 가격 구독 시작
+    useEffect(() => {
+        if (filteredBunnies.length > 0) {
+            filteredBunnies.forEach((bunny) => {
+                startPriceRealtime(bunny.bunny_name);
+            });
+        }
+
+        // 컴포넌트 언마운트 시 구독 해제
+        return () => {
+            if (filteredBunnies.length > 0) {
+                filteredBunnies.forEach((bunny) => {
+                    stopPriceRealtime(bunny.bunny_name);
+                });
+            }
+        };
+    }, [filteredBunnies, startPriceRealtime, stopPriceRealtime]);
 
     if (status.bunnies.isLoading)
         return (

--- a/src/app/personal/home/_constants/constants.ts
+++ b/src/app/personal/home/_constants/constants.ts
@@ -118,7 +118,7 @@ export const BunnyTraitsData = [
 export const fieldList = [
     { key: "bunny_name", label: "버니 이름" },
     { key: "user_name", label: "개발자" },
-    { key: "developer_type", label: "버니 성향" },
+    { key: "developer_type", label: "개발자 유형" },
     { key: "position", label: "포지션" },
     { key: "current_price", label: "현재 가격" },
     { key: "fluctuation_rate", label: "변동률" },

--- a/src/app/personal/home/page.tsx
+++ b/src/app/personal/home/page.tsx
@@ -57,7 +57,7 @@ function Personal() {
                             />
                             <SortButtons>
                                 <SortButton
-                                    text={"버니 타입"}
+                                    text={"버니 유형"}
                                     data={SelectData[0]}
                                     filterKey="bunnyType"
                                 />
@@ -67,7 +67,7 @@ function Personal() {
                                     filterKey="position"
                                 />
                                 <SortButton
-                                    text={"버니 성향"}
+                                    text={"개발자 유형"}
                                     data={SelectData[2]}
                                     filterKey="bunnyTraits"
                                 />

--- a/src/app/personal/trade/[bunnyName]/page.tsx
+++ b/src/app/personal/trade/[bunnyName]/page.tsx
@@ -15,6 +15,7 @@ import { useBunnyStore, Bunny } from "../../../_store/bunnyStore";
 import { getChart, ChartData } from "../../../_api/bunnyAPI";
 import { Cctv } from "lucide-react";
 import SpaceBackground from "../../../_shared/components/SpaceBackground";
+import { webSocketService } from "../../../_utils/websocket";
 
 export default function Trade() {
     const params = useParams();
@@ -67,6 +68,27 @@ export default function Trade() {
         if (currentBunny?.bunny_name) {
             fetchChartData();
         }
+    }, [currentBunny?.bunny_name]);
+
+    // 페이지 진입 시 즉시 웹소켓 연결
+    useEffect(() => {
+        const initializeWebSocket = async () => {
+            try {
+                await webSocketService.connect();
+                console.log('Trade 페이지에서 웹소켓 연결 완료');
+            } catch (error) {
+                console.error('Trade 페이지 웹소켓 연결 실패:', error);
+            }
+        };
+
+        initializeWebSocket();
+
+        // 페이지 언마운트 시 웹소켓 정리
+        return () => {
+            if (currentBunny?.bunny_name) {
+                webSocketService.unsubscribeFromOrderBook(currentBunny.bunny_name);
+            }
+        };
     }, [currentBunny?.bunny_name]);
 
     if (status.allBunnies.isLoading) {
@@ -261,7 +283,6 @@ const ChartBottomLeftBlock = styled.div`
 `;
 
 const TopLeftBlock = styled.div`
-    background-color: rgba(184, 209, 241, 0.17);
     border-radius: 0.75rem;
     padding: 1rem;
     grid-column: 1;
@@ -269,10 +290,18 @@ const TopLeftBlock = styled.div`
     display: flex;
     align-items: center;
     justify-content: center;
+    background: linear-gradient(
+        135deg,
+        rgba(247, 227, 255, 0.305) 0%,
+        rgba(177, 106, 179, 0.292) 50%,
+        rgba(0, 0, 70, 0.284) 100%
+    );
+    backdrop-filter: blur(25px);
+    box-shadow: 0 8px 32px rgba(176, 106, 179, 0.25),
+        0 4px 16px rgba(0, 0, 0, 0.15), inset 0 1px 0 rgba(255, 255, 255, 0.1);
 `;
 
 const MiddleLeftBlock = styled.div`
-    background-color: rgba(184, 209, 241, 0.17);
     border-radius: 1.25rem;
     grid-column: 1;
     grid-row: 2;
@@ -280,10 +309,18 @@ const MiddleLeftBlock = styled.div`
     display: flex;
     flex-direction: column;
     gap: 1rem;
+    background: linear-gradient(
+        135deg,
+        rgba(247, 227, 255, 0.305) 0%,
+        rgba(177, 106, 179, 0.292) 50%,
+        rgba(0, 0, 70, 0.284) 100%
+    );
+    backdrop-filter: blur(25px);
+    box-shadow: 0 8px 32px rgba(176, 106, 179, 0.25),
+        0 4px 16px rgba(0, 0, 0, 0.15), inset 0 1px 0 rgba(255, 255, 255, 0.1);
 `;
 
 const BottomLeftBlock = styled.div`
-    background-color: rgba(184, 209, 241, 0.17);
     border-radius: 1.25rem;
     grid-column: 1;
     grid-row: 3;
@@ -292,6 +329,16 @@ const BottomLeftBlock = styled.div`
     flex-direction: column;
     gap: 0.75rem;
     overflow: hidden;
+
+    background: linear-gradient(
+        135deg,
+        rgba(247, 227, 255, 0.305) 0%,
+        rgba(177, 106, 179, 0.292) 50%,
+        rgba(0, 0, 70, 0.284) 100%
+    );
+    backdrop-filter: blur(25px);
+    box-shadow: 0 8px 32px rgba(176, 106, 179, 0.25),
+        0 4px 16px rgba(0, 0, 0, 0.15), inset 0 1px 0 rgba(255, 255, 255, 0.1);
 `;
 
 const RightSection = styled.div`

--- a/src/app/personal/trade/components/BunnySpec.tsx
+++ b/src/app/personal/trade/components/BunnySpec.tsx
@@ -117,8 +117,8 @@ export default function BunnySpec({ bunny }: BunnySpecProps) {
           {spec.career && spec.career.length > 0 ? (
             spec.career.map((career) => (
               <ExperienceItem key={career.career_id}>
-                <ExperienceInfo> {career.company_name} {career.position} </ExperienceInfo>
-                <ExperienceDate> {formatDateRange(career.start_date, career.end_date)} </ExperienceDate>
+                <ExperienceInfo>{career.company_name} {career.position}</ExperienceInfo>
+                <ExperienceDate>{formatDateRange(career.start_date, career.end_date)}</ExperienceDate>
               </ExperienceItem>
             ))
           ) : (
@@ -138,7 +138,9 @@ export default function BunnySpec({ bunny }: BunnySpecProps) {
           {spec.certification && spec.certification.length > 0 ? (
             spec.certification.map((cert) => (
               <CertificationItem key={cert.certification_id}>
-                <CertificationInfo>{cert.name} ({cert.ca})</CertificationInfo>
+                <CertificationInfo>
+                  {cert.name} <CertificationCA>({cert.ca})</CertificationCA>
+                </CertificationInfo>
                 <CertificationDate>{formatDate(cert.cdate)}</CertificationDate>
               </CertificationItem>
             ))
@@ -271,47 +273,17 @@ const EducationItem = styled.div`
   flex-direction: column;
   gap: 0.1rem;
   margin-bottom: 0.3rem;
-`;
-
-const ExperienceInfo = styled.div`
-  font-size: 0.75rem;
-  color: #fff;
-  line-height: 1.2;
-  font-weight: 500;
+  background: linear-gradient(135deg, rgba(197, 197, 197, 0.15) 0%, rgba(255, 255, 255, 0.1) 100%);
+  padding: 0.4rem 0.6rem;
+  border-radius: 0.4rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(10px);
+  transition: all 0.3s ease;
   
-  @media (max-width: 768px) {
-    font-size: 0.7rem;
-  }
-  
-  @media (max-width: 480px) {
-    font-size: 0.65rem;
-  }
-`;
-
-const ExperienceDate = styled.div`
-  font-size: 0.7rem;
-  color: #ccc;
-  line-height: 1.2;
-  
-  @media (max-width: 768px) {
-    font-size: 0.65rem;
-  }
-  
-  @media (max-width: 480px) {
-    font-size: 0.6rem;
-  }
-`;
-
-const ExperienceItem = styled.div`
-  font-size: 0.75rem;
-  color: #fff;
-  
-  @media (max-width: 768px) {
-    font-size: 0.7rem;
-  }
-  
-  @media (max-width: 480px) {
-    font-size: 0.65rem;
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    background: linear-gradient(135deg, rgba(197, 197, 197, 0.25) 0%, rgba(255, 255, 255, 0.15) 100%);
   }
 `;
 
@@ -331,19 +303,66 @@ const EducationInfo = styled.div`
 `;
 
 const EducationDate = styled.div`
-  font-size: 0.7rem;
+  font-size: 0.6rem;
   color: #ccc;
   line-height: 1.2;
   
   @media (max-width: 768px) {
-    font-size: 0.65rem;
+    font-size: 0.55rem;
   }
   
   @media (max-width: 480px) {
-    font-size: 0.6rem;
+    font-size: 0.5rem;
   }
 `;
 
+const ExperienceItem = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  margin-bottom: 0.3rem;
+  background: linear-gradient(135deg, rgba(197, 197, 197, 0.15) 0%, rgba(255, 255, 255, 0.1) 100%);
+  padding: 0.4rem 0.6rem;
+  border-radius: 0.4rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(10px);
+  transition: all 0.3s ease;
+  
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    background: linear-gradient(135deg, rgba(197, 197, 197, 0.25) 0%, rgba(255, 255, 255, 0.15) 100%);
+  }
+`;
+
+const ExperienceInfo = styled.div`
+  font-size: 0.75rem;
+  color: #fff;
+  line-height: 1.2;
+  font-weight: 500;
+  
+  @media (max-width: 768px) {
+    font-size: 0.7rem;
+  }
+  
+  @media (max-width: 480px) {
+    font-size: 0.65rem;
+  }
+`;
+
+const ExperienceDate = styled.div`
+  font-size: 0.6rem;
+  color: #ccc;
+  line-height: 1.2;
+  
+  @media (max-width: 768px) {
+    font-size: 0.55rem;
+  }
+  
+  @media (max-width: 480px) {
+    font-size: 0.5rem;
+  }
+`;
 
 const CertificationContent = styled.div`
   border-radius: 0.5rem;
@@ -361,9 +380,18 @@ const CertificationItem = styled.div`
   flex-direction: column;
   gap: 0.1rem;
   margin-bottom: 0.3rem;
-  background-color: rgba(197, 197, 197, 0.25);
-  padding: 0.25rem 0.5rem;
-  border-radius: 0.25rem;
+  background: linear-gradient(135deg, rgba(197, 197, 197, 0.15) 0%, rgba(255, 255, 255, 0.1) 100%);
+  padding: 0.4rem 0.6rem;
+  border-radius: 0.4rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(10px);
+  transition: all 0.3s ease;
+  
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    background: linear-gradient(135deg, rgba(197, 197, 197, 0.25) 0%, rgba(255, 255, 255, 0.15) 100%);
+  }
 `;
 
 const CertificationInfo = styled.div`
@@ -381,17 +409,30 @@ const CertificationInfo = styled.div`
   }
 `;
 
+const CertificationCA = styled.span`
+  font-size: 0.65rem;
+  font-weight: 400;
+  
+  @media (max-width: 768px) {
+    font-size: 0.6rem;
+  }
+  
+  @media (max-width: 480px) {
+    font-size: 0.55rem;
+  }
+`;
+
 const CertificationDate = styled.div`
-  font-size: 0.7rem;
+  font-size: 0.6rem;
   color: #ccc;
   line-height: 1.2;
   
   @media (max-width: 768px) {
-    font-size: 0.65rem;
+    font-size: 0.55rem;
   }
   
   @media (max-width: 480px) {
-    font-size: 0.6rem;
+    font-size: 0.5rem;
   }
 `;
 
@@ -402,28 +443,43 @@ const SkillsTags = styled.div`
 `;
 
 const SkillTag = styled.span`
-  background: #AEAEAE;
+  background: linear-gradient(135deg, #AEAEAE 0%, #8A8A8A 100%);
   color: #FFF2C2;
   font-size: 0.65rem;
-  padding: 0.2rem 0.4rem;
-  border-radius: 1rem;
-  font-weight: bold;
+  padding: 0.3rem 0.6rem;
+  border-radius: 1.2rem;
+  font-weight: 600;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  transition: all 0.3s ease;
+  cursor: default;
+  
+  &:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+    background: linear-gradient(135deg, #B8B8B8 0%, #9A9A9A 100%);
+  }
   
   @media (max-width: 768px) {
     font-size: 0.6rem;
-    padding: 0.15rem 0.3rem;
+    padding: 0.25rem 0.5rem;
   }
   
   @media (max-width: 480px) {
     font-size: 0.55rem;
-    padding: 0.1rem 0.25rem;
+    padding: 0.2rem 0.4rem;
   }
 `;
 
 const NoDataMessage = styled.div`
   font-size: 0.75rem;
-  color: #fff;
-  padding: 0.5rem;
+  color: rgba(255, 255, 255, 0.7);
+  padding: 0.8rem;
+  text-align: center;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.05) 0%, rgba(255, 255, 255, 0.02) 100%);
+  border-radius: 0.5rem;
+  border: 1px dashed rgba(255, 255, 255, 0.2);
+  font-style: italic;
   
   @media (max-width: 768px) {
     font-size: 0.7rem;

--- a/src/app/personal/trade/components/CurrentPrice.tsx
+++ b/src/app/personal/trade/components/CurrentPrice.tsx
@@ -9,7 +9,7 @@ interface CurrentPriceProps {
 
 export default function CurrentPrice({ bunny }: CurrentPriceProps) {
   // 스토어에서 실시간 값 읽기
-  const { bunnies, allBunnies, startPriceRealtime, stopPriceRealtime } = useBunnyStore();
+  const { bunnies, allBunnies, startPriceRealtime, stopPriceRealtime, isWebSocketConnected } = useBunnyStore();
 
   // 현재 화면 대상 bunnyName
   const bunnyName = bunny.bunny_name;
@@ -43,7 +43,7 @@ export default function CurrentPrice({ bunny }: CurrentPriceProps) {
     <DashboardContent>
       <PriceSection>
         <MainValue>{price}</MainValue>
-        <StatusDot />
+        <StatusDot $isConnected={isWebSocketConnected()} />
       </PriceSection>
       <ChangeInfo>
         <ChangeValue $isPositive={isPositive}>{change}</ChangeValue>
@@ -67,7 +67,7 @@ const DashboardContent = styled.div`
 const PriceSection = styled.div`
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 1rem;
   margin-bottom: 0.5rem;
 `;
 
@@ -77,15 +77,28 @@ const MainValue = styled.div`
   color: white;
 `;
 
-const StatusDot = styled.div`
+const StatusDot = styled.div<{ $isConnected: boolean }>`
   width: 8px;
   height: 8px;
-  background-color: #FEE2A7;
+  background-color: ${({ $isConnected }) => $isConnected ? '#4ade80' : '#ffc107'};
   border-radius: 50%;
   box-shadow: 
-    inset -0.56px -1.13px 2.81px #FFC54A,
+    inset -0.56px -1.13px 2.81px ${({ $isConnected }) => $isConnected ? '#22c55e' : '#FFC54A'},
     inset 0.56px 0.56px 0.56px #FFFBF2,
-    1px 1px 2px #FEE2A7;
+    1px 1px 2px ${({ $isConnected }) => $isConnected ? '#4ade80' : '#FEE2A7'};
+  
+  ${({ $isConnected }) => $isConnected && `
+    animation: blink 1.5s infinite;
+  `}
+  
+  @keyframes blink {
+    0%, 50% {
+      opacity: 1;
+    }
+    51%, 100% {
+      opacity: 0.3;
+    }
+  }
 `;
 
 const ChangeInfo = styled.div`
@@ -99,18 +112,18 @@ const ChangeInfo = styled.div`
 
 const ChangeValue = styled.span<{ $isPositive: boolean }>`
   font-size: 0.8rem;
-  color: ${({ $isPositive }) => $isPositive ? '#ff4444' : '#4444ff'};
+  color: ${({ $isPositive }) => $isPositive ? 'rgb(255, 90, 90)' : 'rgb(96, 165, 250);'};
   font-weight: bold;
 `;
 
 const ChangePercentage = styled.span<{ $isPositive: boolean }>`
   font-size: 0.8rem;
-  color: ${({ $isPositive }) => $isPositive ? '#ff4444' : '#4444ff'};
+  color: ${({ $isPositive }) => $isPositive ? 'rgb(255, 90, 90)' : 'rgb(96, 165, 250);'};
   font-weight: bold;
 `;
 
 const ChangeArrow = styled.span<{ $isPositive: boolean }>`
   font-size: 0.8rem;
-  color: ${({ $isPositive }) => $isPositive ? '#ff4444' : '#4444ff'};
+  color: ${({ $isPositive }) => $isPositive ? 'rgb(255, 90, 90)' : 'rgb(96, 165, 250);'};
   font-weight: bold;
 `;

--- a/src/app/personal/trade/components/Order.tsx
+++ b/src/app/personal/trade/components/Order.tsx
@@ -85,33 +85,23 @@ export default function Order({ activeTab, setActiveTab, bunny }: OrderProps) {
 
               const next = { ...prev };
 
-              // 매수 upsert
-              diff.bidUpserts.forEach((u) => {
-                const i = next.bids.findIndex((b) => b.price === u.price);
-                if (i >= 0) next.bids[i] = u;
-                else next.bids.push(u);
-              });
-              // 매수 delete (숫자 배열: 가격)
-              diff.bidDeletes.forEach((price) => {
-                next.bids = next.bids.filter((b) => b.price !== price);
-              });
+              // orderUpserts 처리 (매수/매도 통합)
+              if (diff.orderUpserts && Array.isArray(diff.orderUpserts)) {
+                diff.orderUpserts.forEach((order) => {
+                  const i = next.orders.findIndex((o) => o.price === order.price && o.type === order.type);
+                  if (i >= 0) next.orders[i] = { ...order };
+                  else next.orders.push({ ...order });
+                });
+              }
 
-              // 매도 upsert
-              diff.askUpserts.forEach((u) => {
-                const i = next.asks.findIndex((a) => a.price === u.price);
-                if (i >= 0) next.asks[i] = u;
-                else next.asks.push(u);
-              });
-              // 매도 delete (숫자 배열: 가격)
-              diff.askDeletes.forEach((price) => {
-                next.asks = next.asks.filter((a) => a.price !== price);
-              });
+              // orderDeletes 처리 (가격 배열)
+              if (diff.orderDeletes && Array.isArray(diff.orderDeletes)) {
+                diff.orderDeletes.forEach((price) => {
+                  next.orders = next.orders.filter((o) => o.price !== price);
+                });
+              }
 
-              // 정렬 (매수: 내림차순, 매도: 오름차순)
-              next.bids.sort((a, b) => b.price - a.price);
-              next.asks.sort((a, b) => a.price - b.price);
-
-              // 현재가 갱신(optional)
+              // 현재가 갱신
               if (typeof diff.currentPrice === 'number') {
                 next.currentPrice = diff.currentPrice;
               }
@@ -398,10 +388,10 @@ const TabButton = styled.button<{ $active: boolean; $type: 'buy' | 'sell' }>`
 `;
 
 const TradeArea = styled.div`
-  flex: 1;
   background-color: rgba(252, 252, 252, 0.34);
   border-radius: 0 0 0.75rem 0.75rem;
   padding: 0.8rem;
+  height: fit-content;
 `;
 
 const OrderForm = styled.div`

--- a/src/app/personal/trade/components/OrderList.tsx
+++ b/src/app/personal/trade/components/OrderList.tsx
@@ -35,10 +35,8 @@ export default function OrderList({ activeOrderTab, setActiveOrderTab, bunny }: 
   const [isLoading, setIsLoading] = useState(false);
   const wsConnected = useRef(false);
   
-  const maxQuantity = orderBookData ? Math.max(
-    ...orderBookData.bids.map(bid => bid.quantity),
-    ...orderBookData.asks.map(ask => ask.quantity)
-  ) : 0;
+  const maxQuantity = orderBookData && orderBookData.orders.length > 0 ? 
+    Math.max(...orderBookData.orders.map(order => order.quantity)) : 0;
   
   const getQuantityPercentage = (quantity: number) => {
     return maxQuantity > 0 ? (quantity / maxQuantity) * 100 : 0;
@@ -48,6 +46,12 @@ export default function OrderList({ activeOrderTab, setActiveOrderTab, bunny }: 
     const changeRate = ((price - currentPrice) / currentPrice) * 100;
     const sign = changeRate >= 0 ? '+' : '';
     return `${sign}${changeRate.toFixed(2)}%`;
+  };
+
+  const getChangeStatus = (price: number, currentPrice: number): 'positive' | 'negative' | 'neutral' => {
+    if (price > currentPrice) return 'positive';
+    if (price < currentPrice) return 'negative';
+    return 'neutral';
   };
 
   const formatDateTime = (dateTimeString: string): string => {
@@ -66,9 +70,17 @@ export default function OrderList({ activeOrderTab, setActiveOrderTab, bunny }: 
     }
   };
 
-  // WebSocket 연결
-  const connectWebSocket = async () => {
+  // WebSocket 연결 상태 확인 및 필요시 연결
+  const ensureWebSocketConnection = async () => {
     try {
+      // 이미 연결되어 있는지 확인
+      if (webSocketService.client?.connected) {
+        wsConnected.current = true;
+        console.log('WebSocket 이미 연결됨');
+        return;
+      }
+      
+      // 연결되지 않은 경우에만 연결 시도
       await webSocketService.connect();
       wsConnected.current = true;
       console.log('WebSocket 연결 완료');
@@ -81,66 +93,17 @@ export default function OrderList({ activeOrderTab, setActiveOrderTab, bunny }: 
   // 호가창 스냅샷 처리
   const handleOrderBookSnapshot = (snapshot: OrderBookSnapshot) => {
     console.log('호가창 스냅샷 수신:', snapshot);
-    setOrderBookData({
-      bunnyName: snapshot.bunnyName,
-      bids: snapshot.bids,
-      asks: snapshot.asks,
-      currentPrice: snapshot.currentPrice,
-      serverTime: Date.now()
-    });
+  
+    setOrderBookData(snapshot);
   };
 
-  // 호가창 차이 처리
+  // 호가창 차이 처리 - diff 처리가 복잡하므로 스냅샷 재요청
   const handleOrderBookDiff = (diff: OrderBookDiff) => {
-    console.log('호가창 차이 수신:', diff);
-    
-    setOrderBookData(prevData => {
-      if (!prevData) return prevData;
-
-      // 기존 데이터 복사
-      let newBids = [...prevData.bids];
-      let newAsks = [...prevData.asks];
-
-      // Bid 업데이트/삭제
-      diff.bidUpserts.forEach(upsert => {
-        const index = newBids.findIndex(bid => bid.price === upsert.price);
-        if (index >= 0) {
-          newBids[index] = upsert;
-        } else {
-          newBids.push(upsert);
-        }
-      });
-
-      diff.bidDeletes.forEach(del => {
-        newBids = newBids.filter(bid => bid.price !== del.price);
-      });
-
-      // Ask 업데이트/삭제
-      diff.askUpserts.forEach(upsert => {
-        const index = newAsks.findIndex(ask => ask.price === upsert.price);
-        if (index >= 0) {
-          newAsks[index] = upsert;
-        } else {
-          newAsks.push(upsert);
-        }
-      });
-
-      diff.askDeletes.forEach(price => {
-        newAsks = newAsks.filter(ask => ask.price !== price);
-      });
-
-      // 가격순 정렬
-      newBids.sort((a, b) => b.price - a.price);
-      newAsks.sort((a, b) => a.price - b.price);
-
-      return {
-        ...prevData,
-        bids: newBids,
-        asks: newAsks,
-        currentPrice: diff.currentPrice ?? prevData.currentPrice,
-        serverTime: diff.serverTime
-      };
-    });
+    console.log('호가창 차이 수신, 전체 스냅샷 재요청:', diff);
+    // diff 처리 대신 전체 스냅샷을 다시 요청하는 것이 더 안전함
+    if (wsConnected.current) {
+      webSocketService.requestOrderBookSnapshot(bunny.bunny_name);
+    }
   };
 
   const fetchOrderHistory = async () => {
@@ -172,16 +135,19 @@ export default function OrderList({ activeOrderTab, setActiveOrderTab, bunny }: 
   const fetchOrderBook = async () => {
     setIsLoading(true);
     try {
+      // 1. 웹소켓 연결 상태 확인 및 필요시 연결
+      await ensureWebSocketConnection();
+      
       if (wsConnected.current) {
-        // 1. REST API로 초기 스냅샷 가져오기
+        // 2. REST API로 초기 스냅샷 가져오기
         console.log('REST API로 스냅샷 요청:', bunny.bunny_name);
         const snapshot = await getOrderBookSnapshot(bunny.bunny_name);
         console.log('스냅샷 수신:', snapshot);
         
-        // 2. 스냅샷으로 상태 세팅
+        // 3. 스냅샷으로 상태 세팅
         setOrderBookData(snapshot);
         
-        // 3. WebSocket 구독 시작 (이미 연결되어 있음)
+        // 4. WebSocket 구독 시작
         console.log('WebSocket 구독 시작:', bunny.bunny_name);
         webSocketService.subscribeToOrderBook(
           bunny.bunny_name,
@@ -190,6 +156,7 @@ export default function OrderList({ activeOrderTab, setActiveOrderTab, bunny }: 
         );
       } else {
         // HTTP API로 폴백
+        console.log('웹소켓 연결 실패, HTTP API로 폴백');
         const data = await getOrderBookSnapshot(bunny.bunny_name);
         setOrderBookData(data);
       }
@@ -224,31 +191,17 @@ export default function OrderList({ activeOrderTab, setActiveOrderTab, bunny }: 
     }
   }, [bunny.bunny_name, activeOrderTab]);
 
-  // WebSocket 연결 및 정리
+  // 컴포넌트 언마운트 시 WebSocket 정리
   useEffect(() => {
-    const initializeWebSocket = async () => {
-      await connectWebSocket();
-    };
-
-    initializeWebSocket();
-
     return () => {
-      // 컴포넌트 언마운트 시 WebSocket 정리
+      // 컴포넌트 언마운트 시 해당 버니의 구독만 해제
       if (bunny.bunny_name) {
         webSocketService.unsubscribeFromOrderBook(bunny.bunny_name);
       }
-      webSocketService.disconnect();
-    };
-  }, []);
-
-  // bunny 변경 시 이전 구독 해제
-  useEffect(() => {
-    return () => {
-      if (bunny.bunny_name) {
-        webSocketService.unsubscribeFromOrderBook(bunny.bunny_name);
-      }
+      // 웹소켓 연결은 페이지 레벨에서 관리하므로 여기서는 해제하지 않음
     };
   }, [bunny.bunny_name]);
+
 
 
   return (
@@ -285,45 +238,26 @@ export default function OrderList({ activeOrderTab, setActiveOrderTab, bunny }: 
                 <EmptyState>데이터를 불러오는 중...</EmptyState>
               ) : orderBookData ? (
                 <>
-                  {orderBookData.bids.map((bid, index) => (
-                    <OrderItem key={`bid-${index}`}>
+                  {orderBookData.orders.map((order, index) => (
+                    <OrderItem key={`order-${index}`}>
                       <OrderLeftArea>
                         <OrderBar 
-                          $orderType="BUY"
-                          $widthPercentage={getQuantityPercentage(bid.quantity)}
+                          $orderType={order.type}
+                          $widthPercentage={getQuantityPercentage(order.quantity)}
                         >
-                          {bid.quantity}
+                          {order.quantity}
                         </OrderBar>
                       </OrderLeftArea>
                       <OrderRightArea>
-                        <OrderPrice>{bid.price.toLocaleString()}</OrderPrice>
-                        <OrderChange $isPositive={bid.price >= orderBookData.currentPrice}>
-                          {calculateChangeRate(bid.price, orderBookData.currentPrice)}
+                        <OrderPrice>{order.price.toLocaleString()}</OrderPrice>
+                        <OrderChange $changeStatus={getChangeStatus(order.price, orderBookData.currentPrice)}>
+                          {calculateChangeRate(order.price, orderBookData.currentPrice)}
                         </OrderChange>
                       </OrderRightArea>
                     </OrderItem>
                   ))}
                   
-                  {orderBookData.asks.map((ask, index) => (
-                    <OrderItem key={`ask-${index}`}>
-                      <OrderLeftArea>
-                        <OrderBar 
-                          $orderType="SELL"
-                          $widthPercentage={getQuantityPercentage(ask.quantity)}
-                        >
-                          {ask.quantity}
-                        </OrderBar>
-                      </OrderLeftArea>
-                      <OrderRightArea>
-                        <OrderPrice>{ask.price.toLocaleString()}</OrderPrice>
-                        <OrderChange $isPositive={ask.price >= orderBookData.currentPrice}>
-                          {calculateChangeRate(ask.price, orderBookData.currentPrice)}
-                        </OrderChange>
-                      </OrderRightArea>
-                    </OrderItem>
-                  ))}
-                  
-                  {orderBookData.bids.length === 0 && orderBookData.asks.length === 0 && (
+                  {orderBookData.orders.length === 0 && (
                     <EmptyState>호가 데이터가 없습니다.</EmptyState>
                   )}
                 </>
@@ -531,10 +465,21 @@ const OrderPrice = styled.span`
   color: #333;
 `;
 
-const OrderChange = styled.span<{ $isPositive: boolean }>`
+const OrderChange = styled.span<{ $changeStatus: 'positive' | 'negative' | 'neutral' }>`
   font-size: 0.7rem;
   font-weight: 600;
-  color: ${({ $isPositive }) => $isPositive ? '#e74c3c' : '#4a90e2'};
+  color: ${({ $changeStatus }) => {
+    switch ($changeStatus) {
+      case 'positive':
+        return '#e74c3c';
+      case 'negative':
+        return '#4a90e2';
+      case 'neutral':
+        return '#575757';
+      default:
+        return '#6b7280';
+    }
+  }};
 `;
 
 // Order History Styles
@@ -685,4 +630,3 @@ const EmptyState = styled.div`
   font-size: 0.9rem;
   font-weight: 500;
 `;
-

--- a/src/app/personal/trade/components/Trade.tsx
+++ b/src/app/personal/trade/components/Trade.tsx
@@ -78,7 +78,6 @@ const TopSection = styled.div`
 `;
 
 const BottomSection = styled.div`
-  flex: 1;
   display: flex;
   flex-direction: column;
   border-radius: 0.75rem;


### PR DESCRIPTION
## 📌 작업 개요
- 호가창 매수 매도 응답 통합

## ✅ 작업 상세
- 페이지 접속 시 웹소켓 연결로 수정했습니다. 이제 메인페이지, 트레이드 페이지 접속 시 바로 실시간 웹소켓 반영됩니다.
- 트레이드 페이지 현재가에 stat(초록색) 깜빡이도록 했습니다.
- 호가창에서 현재가에 테두리 강조 추가했습니다.
- 수정된 호가창 응답 구조에 맞게 프론트엔드에서도 수정했습니다.
- 트레이드 페이지 프로필 영역 배경 수정했습니다.
- SpaceBackground 하단 가장자리 깨짐 문제 수정했습니다.

## 🎫 관련 이슈
- [RABBIT-135](https://dssw5.atlassian.net/browse/RABBIT-135)

## 🎬 참고 이미지
<img width="367" height="471" alt="image" src="https://github.com/user-attachments/assets/597533be-b466-408d-9e6e-e1bcb6dd5b9b" />
<img width="503" height="975" alt="image" src="https://github.com/user-attachments/assets/b0541f29-bae2-414a-9f31-469620de9cc1" />

## 📎 기타
- 없음.
